### PR TITLE
Fix debug playbook output

### DIFF
--- a/chapter13.txt
+++ b/chapter13.txt
@@ -86,8 +86,6 @@ TASK [Print a message if a command resulted in a change.] ***********
 ok: [127.0.0.1] => {
     "msg": "Command resulted in a change!"
 }
-nge!"
-}
 
 PLAY RECAP **********************************************************
 127.0.0.1            : ok=3    changed=1    unreachable=0    failed=0


### PR DESCRIPTION
@geerlingguy 
In the book, the last few characters of the 'Command resulted in a change! }' output are duplicated.

I think it's quite obvious that this is a small error, nevertheless for completeness, here is the output when I executed the playbook:

```
$ ansible-playbook debug.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

PLAY [127.0.0.1] **************************************************************************************************

TASK [Register the output of the 'uptime' command.] ***************************************************************
changed: [127.0.0.1]

TASK [Print the registered output of the 'uptime' command.] *******************************************************
ok: [127.0.0.1] => {
    "system_uptime.stdout": "17:21  up 21:54, 2 users, load averages: 1.66 2.20 2.82"
}

TASK [Print a message if a command resulted in a change.] *********************************************************
ok: [127.0.0.1] => {
    "msg": "Command resulted in a change!"
}

PLAY RECAP ********************************************************************************************************
127.0.0.1                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```

And for the end, some general words: Thank you very much for this awesome book. I'm digging into Ansible right now, and this resource makes learning it so much easier and fun. 🙏 
