### PR TITLE
Fix running npm package forever in chapter 4

### DIFF
--- a/chapter4.txt
+++ b/chapter4.txt
@@ -393,12 +393,12 @@ We'll now use `forever` (which we installed earlier) to start the app.
 {lang="yaml",starting-line-number=41}
 ```
     - name: Check list of running Node.js apps.
-      command: /usr/local/bin/forever list
+      command: npx forever list
       register: forever_list
       changed_when: false
 
     - name: Start example Node.js app.
-      command: "/usr/local/bin/forever start {{ node_apps_location }}/app/app.js"
+      command: "npx forever start {{ node_apps_location }}/app/app.js"
       when: "forever_list.stdout.find(node_apps_location + \
 '/app/app.js') == -1"
 ```


### PR DESCRIPTION
On some systems the path to the binary of the npm package 'forever' might not be `/usr/local/bin/forever`.

I am currently using a virtual machine running Debian 12.
I installed nodejs 20 with this role https://github.com/geerlingguy/ansible-role-nodejs
and forever based on the example from the book:

```yml
  - name: Ensure Forever is installed.
    npm:
      name: forever
      global: yes
      state: present
```

The examples in the book for running "forever" did not work because it seems that in my case the binary is not located at `/usr/local/bin/forever`.

I think this can be solved by using `npx` to run the command instead.
It should work on any system regardless where npm chooses to install the binary.

I verified the change in my setup and I can access the nodejs app and am seeing "Hello World!" as expected.

Happy New Year !