### PR TITLE
Changed Apache service state from 'running' to 'started'

### DIFF
--- a/chapter5.txt
+++ b/chapter5.txt
@@ -256,7 +256,7 @@ Variable files can also be imported conditionally. Say, for instance, you have o
     - name: Ensure Apache is running.
       service:
         name: "{{ apache_service_name }}"
-        state: running
+        state: started
 ```
 
 Then, add two files in the same folder as your example playbook, `apache_RedHat.yml`, and `apache_default.yml`. Define the variable `apache_service_name: httpd` in the CentOS file, and `apache_service_name: apache2` in the default file.


### PR DESCRIPTION
Hi Jeff,

I was going through the example under the `Playbook Variables` heading in Chapter 5, and noticed that when running the `service` task to start Apache, the `state` was listed as `state: running`, however that gave me the error in the logs below, saying that `running` isn't a valid value of `state`. I believe it should be changed to `state: started`, which worked on my end when I changed it to that and tried it out. I am proposing that change in this pull request.

```
PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [192.168.56.66]

TASK [Include vars file] *******************************************************
ok: [192.168.56.66] => (item=/mnt/d/Documents/ansible/ch05_01/apache_RedHat.yaml)

TASK [Install Apache.] *********************************************************
ok: [192.168.56.66]

TASK [Ensure Apache is running.] ***********************************************
fatal: [192.168.56.66]: FAILED! => {"changed": false, "msg": "value of state must be one of: reloaded, restarted, started, stopped, got: running"}

PLAY RECAP *********************************************************************
192.168.56.66              : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

Thanks for writing this book, it's been very helpful in streamlining my path to competence in Ansible.

Seth