### PR TITLE
Changed digital_ocean_droplet state for deletion from 'deleted' to 'absent'

### DIFF
--- a/chapter8.txt
+++ b/chapter8.txt
@@ -362,7 +362,7 @@ Create a new playbook named `provision.yml`, with the following contents:
       register: do
 ```
 
-The `digital_ocean` module lets you create, manage, and delete droplets with ease. You can read the documentation for all the options, but the above is an overview of the main options. `name` sets the hostname for the droplet, `state` can also be set to `deleted` if you want the droplet to be destroyed, and other options tell DigitalOcean where to set up the droplet, and with what OS and configuration.
+The `digital_ocean` module lets you create, manage, and delete droplets with ease. You can read the documentation for all the options, but the above is an overview of the main options. `name` sets the hostname for the droplet, `state` can also be set to `absent` if you want the droplet to be destroyed, and other options tell DigitalOcean where to set up the droplet, and with what OS and configuration.
 
 T> You can use DigitalOcean's API, along with your Personal Access Token, to get the IDs for `size_id` (the size of the Droplet), `image_id` (the system or distro image to use), `region_id` (the data center in which your droplet will be created), and `ssh_key_ids` (a comma separate list of SSH keys to be included in the root account's `authorized_keys` file).
 T> 


### PR DESCRIPTION
Hi Jeff,

I tried changing the `state` for the `digital_ocean_droplet` module to `deleted` to try deleting the Droplet, as written in the manuscript. However, it gave me an error saying that `deleted` isn't a valid value of `state`. I put the error message below.

```
PLAY [localhost] ***************************************************************

TASK [Create new Droplet.] *****************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, absent, active, inactive, got: deleted"}

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

This PR changes the `state` listed to `absent` in order to delete the Droplet, in order to fix this error. The `absent` value is mentioned in the documentation for deleting a Droplet: [community.digitalocean.digital_ocean_droplet module](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_droplet_module.html#parameter-state)

Thanks,
Seth